### PR TITLE
Add ExecInitializer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.zipkin.brave.ratpack</groupId>
   <artifactId>brave-ratpack</artifactId>
-  <version>2.3.3-SNAPSHOT</version>
+  <version>2.4.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>brave-ratpack</name>
   <description>Brave instrumentation for Ratpack</description>
@@ -50,7 +50,7 @@
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
 
     <brave.version>5.1.5</brave.version>
-    <ratpack.version>1.4.6</ratpack.version>
+    <ratpack.version>1.6.0</ratpack.version>
 
   </properties>
 

--- a/src/main/java/ratpack/zipkin/ServerTracingModule.java
+++ b/src/main/java/ratpack/zipkin/ServerTracingModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -33,10 +33,7 @@ import ratpack.guice.ConfigurableModule;
 import ratpack.handling.HandlerDecorator;
 import ratpack.http.client.HttpClient;
 import ratpack.server.ServerConfig;
-import ratpack.zipkin.internal.DefaultServerTracingHandler;
-import ratpack.zipkin.internal.RatpackCurrentTraceContext;
-import ratpack.zipkin.internal.RatpackHttpServerParser;
-import ratpack.zipkin.internal.ZipkinHttpClientImpl;
+import ratpack.zipkin.internal.*;
 import zipkin2.Endpoint;
 import zipkin2.Span;
 import zipkin2.reporter.Reporter;
@@ -58,6 +55,9 @@ public class ServerTracingModule extends ConfigurableModule<ServerTracingModule.
         .in(Singleton.class);
 
     bind(ZipkinHttpClientImpl.class);
+
+    bind(RatpackCurrentTraceContext.TracingPropagationExecInitializer.class)
+            .in(Singleton.class);
 
     Provider<ServerTracingHandler> serverTracingHandlerProvider =
         getProvider(ServerTracingHandler.class);

--- a/src/main/java/ratpack/zipkin/TracedParallelBatch.java
+++ b/src/main/java/ratpack/zipkin/TracedParallelBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -27,8 +27,13 @@ import ratpack.zipkin.internal.RatpackCurrentTraceContext;
  * which do not "inherit" registries from the calling execution. Consequently,
  * the trace context must be passed explicitly to the forked executions.
  *
+ * @deprecated As of 2.4 brave-ratpack is now providing an {@link ratpack.exec.ExecInitializer} bound in guice by {@link ServerTracingModule}
+ * which will deal with passing tracing contexts around Ratpack executions. The propagation is done in {@link ratpack.zipkin.internal.RatpackCurrentTraceContext.TracingPropagationExecInitializer},
+ * this kind of propagation is only possible with Ratpack version 1.6 and above as the parent execution is now avaialble.
+ *
  * @param <T> the type of value produced by each promise in the batch.
  */
+@Deprecated
 public final class TracedParallelBatch<T> {
 
   private final Iterable<? extends Promise<T>> promises;

--- a/src/main/java/ratpack/zipkin/internal/ZipkinHttpClientImpl.java
+++ b/src/main/java/ratpack/zipkin/internal/ZipkinHttpClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -31,16 +31,15 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import javax.inject.Inject;
 import javax.net.ssl.SSLContext;
+
+import io.netty.handler.ssl.SslContext;
 import ratpack.exec.Promise;
 import ratpack.exec.Result;
 import ratpack.func.Action;
 import ratpack.func.Function;
 import ratpack.http.HttpMethod;
 import ratpack.http.MutableHeaders;
-import ratpack.http.client.HttpClient;
-import ratpack.http.client.ReceivedResponse;
-import ratpack.http.client.RequestSpec;
-import ratpack.http.client.StreamedResponse;
+import ratpack.http.client.*;
 
 /**
  * Decorator that adds Zipkin client logging around {@link HttpClient}.
@@ -75,8 +74,18 @@ public final class ZipkinHttpClientImpl implements HttpClient {
     }
 
     @Override
+    public int getPoolQueueSize() {
+        return delegate.getPoolQueueSize();
+    }
+
+    @Override
     public Duration getReadTimeout() {
         return delegate.getReadTimeout();
+    }
+
+    @Override
+    public Duration getConnectTimeout() {
+        return delegate.getConnectTimeout();
     }
 
     @Override
@@ -85,8 +94,18 @@ public final class ZipkinHttpClientImpl implements HttpClient {
     }
 
     @Override
+    public int getMaxResponseChunkSize() {
+        return delegate.getMaxResponseChunkSize();
+    }
+
+    @Override
     public void close() {
         delegate.close();
+    }
+
+    @Override
+    public HttpClient copyWith(Action<? super HttpClientSpec> action) throws Exception {
+        return delegate.copyWith(action);
     }
 
     @Override
@@ -223,6 +242,11 @@ public final class ZipkinHttpClientImpl implements HttpClient {
         }
 
         @Override
+        public int getRedirects() {
+            return delegate.getRedirects();
+        }
+
+        @Override
         public RequestSpec onRedirect(Function<? super ReceivedResponse, Action<? super RequestSpec>> function) {
 
             Function<? super ReceivedResponse, Action<? super RequestSpec>> wrapped =
@@ -239,6 +263,16 @@ public final class ZipkinHttpClientImpl implements HttpClient {
         }
 
         @Override
+        public SslContext getSslContext() {
+            return delegate.getSslContext();
+        }
+
+        @Override
+        public RequestSpec sslContext(SslContext sslContext) {
+            return delegate.sslContext(sslContext);
+        }
+
+        @Override
         public MutableHeaders getHeaders() {
             return this.delegate.getHeaders();
         }
@@ -247,6 +281,17 @@ public final class ZipkinHttpClientImpl implements HttpClient {
         public RequestSpec maxContentLength(int numBytes) {
             this.delegate.maxContentLength(numBytes);
             return this;
+        }
+
+        @Override
+        public int getMaxContentLength() {
+            return delegate.getMaxContentLength();
+        }
+
+        @Override
+        public RequestSpec responseMaxChunkSize(int i) {
+             this.delegate.responseMaxChunkSize(i);
+             return this;
         }
 
         @Override
@@ -265,9 +310,19 @@ public final class ZipkinHttpClientImpl implements HttpClient {
         }
 
         @Override
+        public HttpMethod getMethod() {
+            return delegate.getMethod();
+        }
+
+        @Override
         public RequestSpec decompressResponse(boolean shouldDecompress) {
             this.delegate.decompressResponse(shouldDecompress);
             return this;
+        }
+
+        @Override
+        public boolean getDecompressResponse() {
+            return delegate.getDecompressResponse();
         }
 
         @Override
@@ -282,9 +337,19 @@ public final class ZipkinHttpClientImpl implements HttpClient {
         }
 
         @Override
+        public Duration getConnectTimeout() {
+            return delegate.getConnectTimeout();
+        }
+
+        @Override
         public RequestSpec readTimeout(Duration duration) {
             this.delegate.readTimeout(duration);
             return this;
+        }
+
+        @Override
+        public Duration getReadTimeout() {
+            return delegate.getReadTimeout();
         }
 
         @Override


### PR DESCRIPTION
To the ServerTracingModule add an ExecInitializer that will propagate tracing context across executions this solves for the Batch usecase.

Bumped the minor version as the changes are new features but should not require code change from the user but does now depend on Ratpack 1.6