### PR TITLE
issue-19: ensure only one trace context is in the registry.

### DIFF
--- a/src/test/groovy/ratpack/zipkin/internal/RatpackCurrentTraceContextSpec.groovy
+++ b/src/test/groovy/ratpack/zipkin/internal/RatpackCurrentTraceContextSpec.groovy
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,9 +15,12 @@ package ratpack.zipkin.internal
 
 import brave.propagation.CurrentTraceContext
 import brave.propagation.TraceContext
+import ratpack.exec.ExecSpec
+import ratpack.exec.Execution
 import ratpack.registry.MutableRegistry
 import ratpack.registry.Registry
 import spock.lang.Specification
+import ratpack.zipkin.internal.RatpackCurrentTraceContext.TraceContextHolder
 
 class RatpackCurrentTraceContextSpec extends Specification {
     MutableRegistry registry = Registry.mutable()
@@ -40,6 +43,7 @@ class RatpackCurrentTraceContextSpec extends Specification {
             def current = traceContext.get()
         expect:
             current == null
+            registry.getAll(TraceContextHolder).size() == 0
     }
 
     def 'When setting TraceContext span, should return same TraceContext'() {
@@ -51,6 +55,7 @@ class RatpackCurrentTraceContextSpec extends Specification {
             def result = traceContext.get()
         then:
             result == expected
+            registry.getAll(TraceContextHolder).size() == 1
     }
 
     def 'When closing a scope, trace context should revert back to previous'() {
@@ -65,6 +70,7 @@ class RatpackCurrentTraceContextSpec extends Specification {
             def traceContext = traceContext.get()
         then:
             expected ==  traceContext
+            registry.getAll(TraceContextHolder).size() == 1
     }
 
 
@@ -80,6 +86,7 @@ class RatpackCurrentTraceContextSpec extends Specification {
             def traceContext = traceContext.get()
         then:
             traceContext == null
+            registry.getAll(TraceContextHolder).size() == 1
     }
 
     def 'When TraceContext is null the context should be cleared'() {
@@ -91,10 +98,12 @@ class RatpackCurrentTraceContextSpec extends Specification {
             def result = traceContext.get()
         then:
             result == expected
+            registry.getAll(TraceContextHolder).size() == 1
         when:
             traceContext.newScope(null)
         then:
             traceContext.get() == null
+            registry.getAll(TraceContextHolder).size() == 1
     }
 
 }

--- a/src/test/groovy/ratpack/zipkin/internal/TracePropagationExecInitializerSpec.groovy
+++ b/src/test/groovy/ratpack/zipkin/internal/TracePropagationExecInitializerSpec.groovy
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package ratpack.zipkin.internal
+
+import brave.propagation.TraceContext
+import ratpack.exec.Execution
+import ratpack.exec.ExecutionRef
+import spock.lang.Specification
+import ratpack.zipkin.internal.RatpackCurrentTraceContext.TraceContextHolder
+import ratpack.zipkin.internal.RatpackCurrentTraceContext.TracingPropagationExecInitializer
+
+class TracePropagationExecInitializerSpec extends Specification {
+
+    def dummyContext() {
+        TraceContext
+                .newBuilder()
+                .traceId(new Random().nextLong())
+                .spanId(new Random().nextLong())
+                .build()
+    }
+
+    def 'should copy context from parent when present'() {
+        given:
+            def initializer = new TracingPropagationExecInitializer()
+            def parent = Mock(ExecutionRef)
+            def execution = Mock(Execution)
+            def parentContext = dummyContext()
+            def parentContextHolder = new TraceContextHolder(parentContext)
+        when:
+            initializer.init(execution)
+        then:
+            1 * execution.maybeParent() >> Optional.of(parent)
+            1 * parent.maybeGet(TraceContextHolder.class) >> Optional.of(parentContextHolder)
+            1 * execution.add(parentContextHolder)
+            0 * _
+    }
+
+    def 'should not copy context when parent is not present'() {
+        given:
+            def initializer = new TracingPropagationExecInitializer()
+            def execution = Mock(Execution)
+        when:
+            initializer.init(execution)
+        then:
+            1 * execution.maybeParent() >> Optional.empty()
+            0 * _
+    }
+
+    def 'should not copy context when parent context is empty'() {
+        given:
+            def initializer = new TracingPropagationExecInitializer()
+            def parent = Mock(ExecutionRef)
+            def execution = Mock(Execution)
+        when:
+            initializer.init(execution)
+        then:
+            1 * execution.maybeParent() >> Optional.of(parent)
+            1 * parent.maybeGet(TraceContextHolder.class) >> Optional.empty()
+            0 * _
+    }
+
+}


### PR DESCRIPTION
- the add method on the Ratpack RegistrySpec is additive in that it doesn't replace existing values but instead adds new values to a stack.
- small cleanup around the ExecInitializer to simplify logic